### PR TITLE
Feature/data image false

### DIFF
--- a/src/mysgen/mysgen.py
+++ b/src/mysgen/mysgen.py
@@ -396,14 +396,14 @@ class MySGEN:
             meta, content = self._parse(item_path)
 
             if item_type == "pages":
-                if "data" in meta:
+                if "data" in meta and meta["data"] is not False:
                     self.pages[item] = DataPage(meta, content, src_path, build_path)
                 else:
                     self.pages[item] = Page(meta, content, src_path, build_path)
             else:
-                if "image" in meta:
+                if "image" in meta and meta["image"] is not False:
                     self.posts[item] = ImagePost(meta, content, src_path, build_path)
-                elif "data" in meta:
+                elif "data" in meta and meta["data"] is not False:
                     self.posts[item] = DataPost(meta, content, src_path, build_path)
                 else:
                     self.posts[item] = Post(meta, content, src_path, build_path)
@@ -469,6 +469,10 @@ class MySGEN:
         """
         for key, value in meta.items():
             if value == "":
+                continue
+
+            if (key == "data" or key == "image") and value == "false":
+                meta[key] = False
                 continue
 
             if key == "date":

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -163,8 +163,11 @@ class TestUnitMySGEN:
             ("posts", [], {}),
             ("pages", ["file"], {}),
             ("pages", ["file"], {"data": "data"}),
+            ("pages", ["file"], {"data": False}),
             ("posts", ["file"], {"image": "image"}),
+            ("posts", ["file"], {"image": False}),
             ("posts", ["file"], {"data": "data"}),
+            ("posts", ["file"], {"data": False}),
             ("posts", ["file"], {}),
         ],
     )
@@ -208,14 +211,14 @@ class TestUnitMySGEN:
             mysgen.find_and_parse(item_type)
 
             if item_type == "pages":
-                if "data" in meta:
+                if "data" in meta and meta["data"] is not False:
                     mock_datapage.assert_called_once()
                 else:
                     mock_page.assert_called_once()
             else:
-                if "image" in meta:
+                if "image" in meta and meta["image"] is not False:
                     mock_imagepost.assert_called_once()
-                elif "data" in meta:
+                elif "data" in meta and meta["data"] is not False:
                     mock_datapost.assert_called_once()
                 else:
                     mock_post.assert_called_once()
@@ -297,6 +300,8 @@ class TestUnitMySGEN:
             "tags": ["a, b"],
             "category": ["c"],
             "test": "",
+            "data": "false",
+            "image": "false",
         }
         meta_return = mysgen._format_metadata(meta)
 
@@ -305,6 +310,8 @@ class TestUnitMySGEN:
             "tags": ["a", " b"],
             "category": "c",
             "test": "",
+            "data": False,
+            "image": False,
         }
         assert meta_return == meta_answer
 


### PR DESCRIPTION
## Description

Allow the meta fields `data`and `image`to be `false`, hence present, but without trying to copy data that isn't there. Close #45.